### PR TITLE
Removed 'Account Lock' capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ optional arguments:
                         Enables a user account with the given name
   --disable DISABLE, -disable DISABLE
                         Disabled a user account with the given name
-  --lock LOCK, -lock LOCK
-                        Locks a user account with the given name
   --unlock UNLOCK, -unlock UNLOCK
                         Unlocks a user account with the given name
 ```
@@ -220,8 +218,6 @@ Based on the parameters, it will display, add, delete, or modify user accounts.
     * Example: `rf_accounts -u root -p root -r https://192.168.1.100 -enable user_to_change`
 * The *disable* argument is used to disable a user account
     * Example: `rf_accounts -u root -p root -r https://192.168.1.100 -disable user_to_change`
-* The *lock* argument is used to lock a user account
-    * Example: `rf_accounts -u root -p root -r https://192.168.1.100 -lock user_to_change`
 * The *unlock* argument is used to unlock a user account
     * Example: `rf_accounts -u root -p root -r https://192.168.1.100 -unlock user_to_change`
 * If none of the above arguments are given, a table of the user accounts is provided

--- a/scripts/rf_accounts
+++ b/scripts/rf_accounts
@@ -27,7 +27,6 @@ argget.add_argument( "--setpassword", "-setpassword", type = str, nargs = 2, met
 argget.add_argument( "--setrole", "-setrole", type = str, nargs = 2, metavar = ( "name", "new_role" ), help = "Sets a user account to a new role" )
 argget.add_argument( "--enable", "-enable", type = str, help = "Enables a user account with the given name" )
 argget.add_argument( "--disable", "-disable", type = str, help = "Disabled a user account with the given name" )
-argget.add_argument( "--lock", "-lock", type = str, help = "Locks a user account with the given name" )
 argget.add_argument( "--unlock", "-unlock", type = str, help = "Unlocks a user account with the given name" )
 args = argget.parse_args()
 
@@ -64,10 +63,6 @@ try:
     if args.disable is not None:
         print( "Disabling user '{}'".format( args.disable ) )
         redfish_utilities.modify_user( redfish_obj, args.disable, new_enabled = False )
-        print_accounts = False
-    if args.lock is not None:
-        print( "Locking user '{}'".format( args.lock ) )
-        redfish_utilities.modify_user( redfish_obj, args.lock, new_locked = True )
         print_accounts = False
     if args.unlock is not None:
         print( "Unlocking user '{}'".format( args.unlock ) )


### PR DESCRIPTION
Normally, administrators can unlock accounts but not lock them. Services are the ones that internally lock accounts.