### PR TITLE
Added usage of ETags when issuing PATCH to a System resource

### DIFF
--- a/redfish_utilities/systems.py
+++ b/redfish_utilities/systems.py
@@ -90,7 +90,11 @@ def set_system_boot( context, system_id = None, ov_target = None, ov_enabled = N
         payload["Boot"]["BootNext"] = ov_boot_next
 
     # Update the system
-    response = context.patch( system.dict["@odata.id"], body = payload )
+    headers = None
+    etag = system.getheader( "ETag" )
+    if etag is not None:
+        headers = { "If-Match": etag }
+    response = context.patch( system.dict["@odata.id"], body = payload, headers = headers )
     verify_response( response )
     return response
 


### PR DESCRIPTION
Fix #22 

@jukosone unfortunately I do not have access to a service that uses ETags on Systems, so I've only been able to verify I haven't broken anything with equipment available to me. Would you be able to test this change on your end?