### PR TITLE
Added discover tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ You may install the external modules by running:
 ## Utilities
 
 
+### Discover
+
+```
+usage: rf_discover.py [-h]
+
+A tool to discover Redfish services
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+Example: `rf_discover.py`
+
+The tool will perform an SSDP request to find all available Redfish services.
+Once all of the responses are collected, it will print each service with its UUID and service root.
+
+
 ### Sensor List
 
 ```

--- a/scripts/rf_discover.py
+++ b/scripts/rf_discover.py
@@ -1,0 +1,28 @@
+#! /usr/bin/python
+# Copyright Notice:
+# Copyright 2020 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tacklebox/blob/master/LICENSE.md
+
+"""
+Redfish Discover
+
+File : rf_discover.py
+
+Brief : This script uses the redfish module to discover Redfish services
+"""
+
+import argparse
+import redfish
+
+# No arguments, but having help text is useful
+argget = argparse.ArgumentParser( description = "A tool to discover Redfish services" )
+args = argget.parse_args()
+
+# Invoke the discovery routine for SSDP and print the responses
+services = redfish.discover_ssdp()
+if len( services ) == 0:
+    print( "No Redfish services discovered" )
+else:
+    print( "Redfish services:" )
+for service in services:
+    print( "{}: {}".format( service, services[service] ) )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     scripts = [
         "scripts/rf_accounts.py",
         "scripts/rf_boot_override.py",
+        "scripts/rf_discover.py",
         "scripts/rf_power_reset.py",
         "scripts/rf_sensor_list.py",
         "scripts/rf_sys_inventory.py",


### PR DESCRIPTION
Doesn't actually leverage the library aspect of Tacklebox since everything is already baked into the Python library, but now there's a simple script a user can invoke if they have the latest version of Tacklebox installed.

Sample output (I replaced IP addresses with `<ip>`):
```
rf_discover.py
Redfish services:
60ff44a1-3c34-4fd9-9a87-56c5e903a9de: https://<ip>/redfish/v1/
dee91850-ad66-49a9-b319-2a2131c4068e: https://<ip>/redfish/v1/
f0873dbe-7b29-4ea1-90e7-e4cd01ba78ce: https://<ip>/redfish/v1/
03fff361-3520-421f-9511-71b97093cb79: https://<ip>/redfish/v1/
44ca2499-20ba-44bd-b2f7-8b62da987d76: https://<ip>/redfish/v1/
```