### PR TITLE
Removed 'PushPowerButton' from list of auto-reset selection

### DIFF
--- a/redfish_utilities/systems.py
+++ b/redfish_utilities/systems.py
@@ -198,8 +198,6 @@ def system_reset( context, system_id = None, reset_type = None ):
             if param["Name"] == "ResetType":
                 if "GracefulRestart" in param["AllowableValues"]:
                     reset_type = "GracefulRestart"
-                elif "PushPowerButton" in param["AllowableValues"]:
-                    reset_type = "PushPowerButton"
                 elif "ForceRestart" in param["AllowableValues"]:
                     reset_type = "ForceRestart"
                 elif "PowerCycle" in param["AllowableValues"]:


### PR DESCRIPTION
Depending on the state of the system (and its design), this might not reset a system, but rather the end result might change its power state, which is confusing since the simple semantics are to just reset the system (and it's back up and running when the reset is complete).