### PR TITLE
Added rf_virtual_media.py tool for managing virtual media on a system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Redfish Tacklebox
 
-Copyright 2019-2020 DMTF. All rights reserved.
+Copyright 2019-2021 DMTF. All rights reserved.
 
 ## About
 
-Redfish Tacklebox contains a set of Python utilities to perform common management operations with a Redfish service.
+Redfish Tacklebox contains a set of Python3 utilities to perform common management operations with a Redfish service.
 The utilities can be used as part of larger management applications, or be used as standalone command line tools.
 
 ## Installation
@@ -424,7 +424,6 @@ optional arguments:
                         A list of resource types for the subscription
   --registries REGISTRIES [REGISTRIES ...], -reg REGISTRIES [REGISTRIES ...]
                         A list of registries for the subscription
-
 ``` 
 
 Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 subscribe -dest http://someremotelistener/redfish_event_handler`
@@ -451,6 +450,100 @@ Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 unsubscri
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then locate the event service and traverse the members of the event destination collection to find a member with the `Id` property matching the *id* argument.
 If a match is found, it will perform a DELETE on the member.
+
+
+### Virtual Media
+
+```
+usage: rf_virtual_media.py [-h] --user USER --password PASSWORD --rhost RHOST
+                           [--system SYSTEM]
+                           {info,insert,eject} ...
+
+A tool to manage virtual media of a system
+
+positional arguments:
+  {info,insert,eject}
+    info                Displays information about the virtual media for a
+                        system
+    insert              Inserts virtual media for a system
+    eject               Ejects virtual media from a system
+
+required arguments:
+  --user USER, -u USER  The user name for authentication
+  --password PASSWORD, -p PASSWORD
+                        The password for authentication
+  --rhost RHOST, -r RHOST
+                        The address of the Redfish service (with scheme)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --system SYSTEM, -s SYSTEM
+                        The ID of the system perform the operation
+```
+
+#### Info
+
+```
+usage: rf_virtual_media.py info [-h]
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+Example: `rf_virtual_media.py -u root -p root -r https://192.168.1.100 info`
+
+The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
+It will then locate the system specified by the *system* argument, find its virtual media collection, and display the virtual media instances.
+
+
+#### Insert
+
+```
+usage: rf_virtual_media.py insert [-h] --image IMAGE [--id ID] [--notinserted]
+                                  [--writable]
+                                  [--mediatypes MEDIATYPES [MEDIATYPES ...]]
+
+required arguments:
+  --image IMAGE, -image IMAGE
+                        The URI of the image to insert
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --id ID, -i ID        The identifier of the virtual media instance to insert
+  --notinserted, -notinserted
+                        Indicates if the media is to be marked as not inserted
+                        for the system
+  --writable, -writable
+                        Indicates if the media is to be marked as writable for
+                        the system
+  --mediatypes MEDIATYPES [MEDIATYPES ...], -mt MEDIATYPES [MEDIATYPES ...]
+                        A list of acceptable media types for the virtual media
+``` 
+
+Example: `rf_virtual_media.py -u root -p root -r https://192.168.1.100 insert -image http://somefileserver/my_media.iso`
+
+The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
+It will then locate the system specified by the *system* argument, find its virtual media collection.
+It will then iterate through the virtual media collection, and insert the virtual media specified by the *image* argument in an appropriate slot.
+
+
+#### Eject
+
+```
+usage: rf_virtual_media.py eject [-h] --id ID
+
+required arguments
+  --id ID, -i ID  The identifier of the virtual media instance to eject
+
+optional arguments:
+  -h, --help      show this help message and exit
+```
+
+Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 unsubscribe -id 1`
+
+The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
+It will then locate the system specified by the *system* argument, find its virtual media collection.
+It will then locate the virtual media instance with matching `Id` property with the *id* argument, and then eject the media.
 
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ optional arguments:
   -h, --help      show this help message and exit
 ```
 
-Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 eject -id 1`
+Example: `rf_virtual_media.py -u root -p root -r https://192.168.1.100 eject -id 1`
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then locate the system specified by the *system* argument, find its virtual media collection.

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ optional arguments:
   -h, --help      show this help message and exit
 ```
 
-Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 unsubscribe -id 1`
+Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 eject -id 1`
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then locate the system specified by the *system* argument, find its virtual media collection.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ optional arguments:
   -h, --help      show this help message and exit
 ```
 
-Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 unsubscribe -id 1`
+Example: `rf_event_service.py -u root -p root -r https://192.168.1.100 unsubscribe --id 1`
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then locate the event service and traverse the members of the event destination collection to find a member with the `Id` property matching the *id* argument.
@@ -539,7 +539,7 @@ optional arguments:
   -h, --help      show this help message and exit
 ```
 
-Example: `rf_virtual_media.py -u root -p root -r https://192.168.1.100 eject -id 1`
+Example: `rf_virtual_media.py -u root -p root -r https://192.168.1.100 eject --id 1`
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then locate the system specified by the *system* argument, find its virtual media collection.

--- a/redfish_utilities/__init__.py
+++ b/redfish_utilities/__init__.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 # Copyright Notice:
-# Copyright 2019-2020 DMTF. All rights reserved.
+# Copyright 2019-2021 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tacklebox/blob/master/LICENSE.md
 
 from .accounts import get_users
@@ -31,6 +31,10 @@ from .systems import set_system_boot
 from .systems import print_system_boot
 from .systems import get_system_reset_info
 from .systems import system_reset
+from .systems import get_virtual_media
+from .systems import print_virtual_media
+from .systems import insert_virtual_media
+from .systems import eject_virtual_media
 from .systems import get_system_bios
 from .systems import set_system_bios
 from .systems import print_system_bios

--- a/scripts/rf_virtual_media.py
+++ b/scripts/rf_virtual_media.py
@@ -1,0 +1,52 @@
+#! /usr/bin/python
+# Copyright Notice:
+# Copyright 2021 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tacklebox/blob/master/LICENSE.md
+
+"""
+Redfish Virtual Media
+
+File : rf_virtual_media.py
+
+Brief : This script uses the redfish_utilities module to manage virtual media
+"""
+
+import argparse
+import redfish
+import redfish_utilities
+
+# Get the input arguments
+argget = argparse.ArgumentParser( description = "A tool to manage virtual media of a system" )
+argget.add_argument( "--user", "-u", type = str, required = True, help = "The user name for authentication" )
+argget.add_argument( "--password", "-p",  type = str, required = True, help = "The password for authentication" )
+argget.add_argument( "--rhost", "-r", type = str, required = True, help = "The address of the Redfish service (with scheme)" )
+argget.add_argument( "--system", "-s", type = str, help = "The ID of the system perform the operation" )
+subparsers = argget.add_subparsers( dest = "command" )
+info_argget = subparsers.add_parser( "info", help = "Displays information about the virtual media for a system" )
+insert_argget = subparsers.add_parser( "insert", help = "Inserts virtual media for a system" )
+insert_argget.add_argument( "--image", "-image", type = str, required = True, help = "The URI of the image to insert" )
+insert_argget.add_argument( "--id", "-i", type = str, help = "The identifier of the virtual media instance to insert" )
+insert_argget.add_argument( "--notinserted", "-notinserted", action = "store_false", help = "Indicates if the media is to be marked as not inserted for the system", default = None )
+insert_argget.add_argument( "--writable", "-writable", action = "store_false", help = "Indicates if the media is to be marked as writable for the system", default = None )
+insert_argget.add_argument( "--mediatypes", "-mt", type = str, nargs = '+', help = "A list of acceptable media types for the virtual media" )
+eject_argget = subparsers.add_parser( "eject", help = "Ejects virtual media from a system" )
+eject_argget.add_argument( "--id", "-i", type = str, required = True, help = "The identifier of the virtual media instance to eject" )
+args = argget.parse_args()
+
+# Set up the Redfish object
+redfish_obj = redfish.redfish_client( base_url = args.rhost, username = args.user, password = args.password )
+redfish_obj.login( auth = "session" )
+
+try:
+    if args.command == "insert":
+        print( "Inserting '{}'".format( args.image ) )
+        redfish_utilities.insert_virtual_media( redfish_obj, args.image, args.system, args.id, args.mediatypes, args.notinserted, args.writable )
+    elif args.command == "eject":
+        print( "Ejecting '{}'".format( args.id ) )
+        redfish_utilities.eject_virtual_media (redfish_obj, args.id, args.system )
+    else:
+        virtual_media = redfish_utilities.get_virtual_media( redfish_obj, args.system )
+        redfish_utilities.print_virtual_media( virtual_media )
+finally:
+    # Log out
+    redfish_obj.logout()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 # Copyright Notice:
-# Copyright 2019-2020 DMTF. All rights reserved.
+# Copyright 2019-2021 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tacklebox/blob/master/LICENSE.md
 
 from setuptools import setup
@@ -18,9 +18,9 @@ setup(
     author = "DMTF, https://www.dmtf.org/standards/feedback",
     license = "BSD 3-clause \"New\" or \"Revised License\"",
     classifiers = [
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Topic :: Communications"
     ],
     keywords = "Redfish",
@@ -36,7 +36,8 @@ setup(
         "scripts/rf_power_reset.py",
         "scripts/rf_sensor_list.py",
         "scripts/rf_sys_inventory.py",
-        "scripts/rf_update.py"
+        "scripts/rf_update.py",
+        "scripts/rf_virtual_media.py"
     ],
     install_requires = [ "redfish" ]
 )


### PR DESCRIPTION
rf_virtual_media.py has three commands:
* info: Read and print all virtual media instances
* insert: Specify a URI for an image and perform an InsertMedia action (or PATCH) on an appropriate virtual media instance
* eject: Perform an EjectMedia action (or PATCH) on a specified virtual media instance