### PR TITLE
Enhancement added to fall back on using the Id property in Sensor for building the name if Name is not valid

### DIFF
--- a/redfish_utilities/sensors.py
+++ b/redfish_utilities/sensors.py
@@ -372,8 +372,12 @@ def get_sensor_status( sensor, readings ):
     if reading_val is None:
         reading_val = state
 
+    name = sensor.get( "Name", None )
+    if name is None:
+        name = "Sensor " + sensor["Id"]
+
     reading = {
-        "Name": sensor["Name"],
+        "Name": name,
         "Reading": reading_val,
         "Units": units,
         "State": state,


### PR DESCRIPTION
Current library will throw an exception if "Name" is not present in the payload when building the sensor tables, and throws an exception if Name is null when printing the sensor info.