### PR TITLE
Moved usage of 'workarounds' flag to be a module-level flag rather than an individual parameter on each method

### DIFF
--- a/redfish_utilities/__init__.py
+++ b/redfish_utilities/__init__.py
@@ -55,3 +55,5 @@ from .systems import print_system_bios
 from .tasks import poll_task_monitor
 from .update import get_simple_update_info
 from .update import simple_update
+
+from . import config

--- a/redfish_utilities/config.py
+++ b/redfish_utilities/config.py
@@ -1,0 +1,17 @@
+#! /usr/bin/python
+# Copyright Notice:
+# Copyright 2019-2022 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tacklebox/blob/master/LICENSE.md
+
+"""
+Configuration Settings
+
+File : config.py
+
+Brief : This file contains configuration settings for the module; useful for
+        debugging issues encountered on live systems
+"""
+
+# Leverage known workarounds for non-conformant services, such as bypassing
+# unexpected 4XX responses, missing properties, and malformed URIs
+__workarounds__ = False

--- a/scripts/rf_bios_settings.py
+++ b/scripts/rf_bios_settings.py
@@ -25,13 +25,16 @@ argget.add_argument( "--attribute", "-a", type = str, nargs = 2, metavar = ( "na
 argget.add_argument( "--workaround", "-workaround", action = "store_true", help = "Indicates if workarounds should be attempted for non-conformant services", default = False )
 args = argget.parse_args()
 
+if args.workaround:
+    redfish_utilities.config.__workarounds__ = True
+
 # Set up the Redfish object
 redfish_obj = redfish.redfish_client( base_url = args.rhost, username = args.user, password = args.password )
 redfish_obj.login( auth = "session" )
 
 try:
     # Get the BIOS settings
-    current_settings, future_settings = redfish_utilities.get_system_bios( redfish_obj, args.system, args.workaround )
+    current_settings, future_settings = redfish_utilities.get_system_bios( redfish_obj, args.system )
 
     if args.attribute is not None:
         new_settings = {}

--- a/scripts/rf_sys_inventory.py
+++ b/scripts/rf_sys_inventory.py
@@ -27,18 +27,20 @@ argget.add_argument( "--write", "-w", nargs = "?", const = "Device_Inventory", t
 argget.add_argument( "--workaround", "-workaround", action = "store_true", help = "Indicates if workarounds should be attempted for non-conformant services", default = False )
 args = argget.parse_args()
 
+if args.workaround:
+    redfish_utilities.config.__workarounds__ = True
+
 # Set up the Redfish object
 redfish_obj = redfish.redfish_client( base_url = args.rhost, username = args.user, password = args.password )
 redfish_obj.login( auth = "session" )
 
 try:
     # Get and print the system inventory
-    inventory = redfish_utilities.get_system_inventory( redfish_obj, args.workaround )
+    inventory = redfish_utilities.get_system_inventory( redfish_obj )
     redfish_utilities.print_system_inventory( inventory, args.details, args.noabsent )
 
     if args.write:
         redfish_utilities.write_system_inventory( inventory, args.write )
-
 finally:
     # Log out
     redfish_obj.logout()


### PR DESCRIPTION
Since 'workarounds' can grow quite a bit over time, rather than updating the arguments for every method, use a common variable to signify when to leverage known workarounds.