### PR TITLE
Clarified the usage of omitting the 'target' argument in rf_boot_override.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ optional arguments:
                         The ID of the system to set
   --info, -info         Indicates if boot information should be reported
   --target TARGET, -t TARGET
-                        The target boot device; if not provided the tool will
-                        display the current boot settings
+                        The target boot device; if this argument is omitted
+                        the tool will display the current boot settings
   --uefi UEFI, -uefi UEFI
                         If target is 'UefiTarget', the UEFI Device Path of the
                         device to boot. If target is 'UefiBootNext', the UEFI

--- a/scripts/rf_boot_override.py
+++ b/scripts/rf_boot_override.py
@@ -23,7 +23,7 @@ argget.add_argument( "--password", "-p",  type = str, required = True, help = "T
 argget.add_argument( "--rhost", "-r", type = str, required = True, help = "The address of the Redfish service (with scheme)" )
 argget.add_argument( "--system", "-s", type = str, help = "The ID of the system to set" )
 argget.add_argument( "--info", "-info", action = "store_true", help = "Indicates if boot information should be reported" )
-argget.add_argument( "--target", "-t", type = str, help = "The target boot device; if not provided the tool will display the current boot settings" )
+argget.add_argument( "--target", "-t", type = str, help = "The target boot device; if this argument is omitted the tool will display the current boot settings" )
 argget.add_argument( "--uefi", "-uefi", type = str, help = "If target is 'UefiTarget', the UEFI Device Path of the device to boot.  If target is 'UefiBootNext', the UEFI Boot Option string of the device to boot." )
 argget.add_argument( "--mode", "-m", type = str, help = "The requested boot mode ('UEFI' or 'Legacy')" )
 argget.add_argument( "--reset", "-reset", action = "store_true", help = "Signifies that the system is reset after the boot override is set" )


### PR DESCRIPTION
Fix #76 