### PR TITLE
Add repairability to the inventory catalog

### DIFF
--- a/redfish_utilities/inventory.py
+++ b/redfish_utilities/inventory.py
@@ -196,6 +196,18 @@ def catalog_resource( context, resource, inventory, chassis_id ):
     if resource_type == "Drive":
         location_prop = "PhysicalLocation"
 
+    # Determine whether this unit can be replaced
+    replaceable = None
+    if resource_type == "Chassis" or resource_type == "Processor":
+        replaceable = resource.get("Replaceable", None )
+    if not replaceable:
+        location_type = resource.get( location_prop, {} ).get( "PartLocation", {} ).get( "LocationType", None )
+        if location_type:
+            if location_type == "Embedded":
+                replaceable = False
+            else:
+                replaceable = True
+
     # Pull out all relevant properties for the catalog
     catalog = {
         "Uri": resource["@odata.id"],
@@ -207,7 +219,8 @@ def catalog_resource( context, resource, inventory, chassis_id ):
         "AssetTag": resource.get( "AssetTag", None ),
         "Label": resource.get( location_prop, {} ).get( "PartLocation", {} ).get( "ServiceLabel", None ),
         "State": resource.get( "Status", {} ).get( "State", None ),
-        "Description": None
+        "Description": None,
+        "Replaceable": replaceable
     }
 
     # If no label was found, build a default name


### PR DESCRIPTION
The motivation for this is part of https://github.com/DMTF/Redfish-Usecase-Checkers/issues/62, where we'd like to create a usecase checker for assigning location-based identifiers for replaceable components in a system.

The motivation for that Usecase Checker is to help codify the Google repair identifier requirements documented in https://github.com/google/ecclesia-machine-management/blob/master/ecclesia/lib/redfish/g3doc/topology.md

Signed-off-by: Derek Chan <dchanman@google.com>