### PR TITLE
Reset type updates for systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,8 @@ Once the desired log service is found, the tool will either perform the `ClearLo
 ```
 usage: rf_power_reset.py [-h] --user USER --password PASSWORD --rhost RHOST
                          [--system SYSTEM]
-                         [--type {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle}]
+                         [--type {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle,Suspend,Pause,Resume}]
                          [--info]
-
 
 A tool to perform a power/reset operation of a system
 
@@ -178,7 +177,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --system SYSTEM, -s SYSTEM
                         The ID of the system to reset
-  --type {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle}, -t {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle}
+  --type {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle,Suspend,Pause,Resume}, -t {On,ForceOff,GracefulShutdown,GracefulRestart,ForceRestart,Nmi,ForceOn,PushPowerButton,PowerCycle,Suspend,Pause,Resume}
+                        The type of power/reset operation to perform
   --info, -info         Indicates if reset and power information should be
                         reported
 ```

--- a/redfish_utilities/resets.py
+++ b/redfish_utilities/resets.py
@@ -12,4 +12,5 @@ Brief : This file contains the common definitions and functionalities for
         reset operations
 """
 
-reset_types = [ "On", "ForceOff", "GracefulShutdown", "GracefulRestart", "ForceRestart", "Nmi", "ForceOn", "PushPowerButton", "PowerCycle" ]
+reset_types = [ "On", "ForceOff", "GracefulShutdown", "GracefulRestart", "ForceRestart", "Nmi", "ForceOn",
+                "PushPowerButton", "PowerCycle", "Suspend", "Pause", "Resume" ]

--- a/scripts/rf_power_reset.py
+++ b/scripts/rf_power_reset.py
@@ -44,7 +44,7 @@ try:
         if "PowerState" in system_info.dict:
             print( "Current power state: {}".format( system_info.dict["PowerState"] ) )
         else:
-            print( "No power state information found")
+            print( "No power state information found" )
     else:
         print( "Resetting the system..." )
         response = redfish_utilities.system_reset( redfish_obj, args.system, args.type )


### PR DESCRIPTION
Fix #82 

* Updated allowable reset types to include 'Suspend', 'Pause', and 'Resume'
* Updated error path for system reset requests to append reset types allowed by the system to the exception message