### PR TITLE
Corrected flow when handling system reset exceptions to ensure it stays raised

### DIFF
--- a/redfish_utilities/systems.py
+++ b/redfish_utilities/systems.py
@@ -312,13 +312,14 @@ def system_reset( context, system_id = None, reset_type = None ):
     try:
         verify_response( response )
     except Exception as e:
+        additional_message = ""
         if response.status == 400:
             # Append the list of valid reset types to 400 Bad Request responses
-            supported_reset_types = "No supported reset types listed"
+            additional_message = "\nNo supported reset types listed"
             for param in reset_parameters:
                 if param["Name"] == "ResetType" and "AllowableValues" in param:
-                    supported_reset_types = "Supported reset types: {}".format( ", ".join( param["AllowableValues"] ) )
-            raise type( e )( str( e ) + "\n" + supported_reset_types ).with_traceback( sys.exc_info()[2] )
+                    additional_message = "\nSupported reset types: {}".format( ", ".join( param["AllowableValues"] ) )
+        raise type( e )( str( e ) + additional_message ).with_traceback( sys.exc_info()[2] )
     return response
 
 def get_virtual_media( context, system_id = None ):


### PR DESCRIPTION
Found bug in recent change where if the HTTP status is not 400, the exception is silently dropped.