### PR TITLE
Updated setnet in rf_manager_config.py to allow for the 'Enabled' value for DHCPv6 control

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ usage: rf_manager_config.py setnet [-h] [--id ID] [--ipv4address IPV4ADDRESS]
                                    [--dhcpv4 {On,Off}]
                                    [--ipv6addresses IPV6ADDRESSES [IPV6ADDRESSES ...]]
                                    [--ipv6gateways IPV6GATEWAYS [IPV6GATEWAYS ...]]
-                                   [--dhcpv6 {Stateful,Stateless,Disabled}]
+                                   [--dhcpv6 {Stateful,Stateless,Disabled,Enabled}]
                                    [--vlan {On,Off}] [--vlanid VLANID]
                                    [--vlanpriority VLANPRIORITY]
 
@@ -360,7 +360,7 @@ optional arguments:
   --ipv6gateways IPV6GATEWAYS [IPV6GATEWAYS ...], -ipv6gateways IPV6GATEWAYS [IPV6GATEWAYS ...]
                         The static IPv6 default gateways to set with prefix
                         length
-  --dhcpv6 {Stateful,Stateless,Disabled}, -dhcpv6 {Stateful,Stateless,Disabled}
+  --dhcpv6 {Stateful,Stateless,Disabled,Enabled}, -dhcpv6 {Stateful,Stateless,Disabled,Enabled}
                         The DHCPv6 configuration to set
   --vlan {On,Off}, -vlan {On,Off}
                         The VLAN enabled configuration to set

--- a/scripts/rf_manager_config.py
+++ b/scripts/rf_manager_config.py
@@ -40,7 +40,7 @@ setnet_argget.add_argument( "--ipv4gateway", "-ipv4gateway", type = str, help = 
 setnet_argget.add_argument( "--dhcpv4", "-dhcpv4", type = str, help = "The DHCPv4 configuration to set", choices = [ "On", "Off" ] )
 setnet_argget.add_argument( "--ipv6addresses", "-ipv6addresses", type = str, nargs = '+', help = "The static IPv6 addresses to set with prefix length" )
 setnet_argget.add_argument( "--ipv6gateways", "-ipv6gateways", type = str, nargs = '+', help = "The static IPv6 default gateways to set with prefix length" )
-setnet_argget.add_argument( "--dhcpv6", "-dhcpv6", type = str, help = "The DHCPv6 configuration to set", choices = [ "Stateful", "Stateless", "Disabled" ] )
+setnet_argget.add_argument( "--dhcpv6", "-dhcpv6", type = str, help = "The DHCPv6 configuration to set", choices = [ "Stateful", "Stateless", "Disabled", "Enabled" ] )
 setnet_argget.add_argument( "--vlan", "-vlan", type = str, help = "The VLAN enabled configuration to set", choices = [ "On", "Off" ] )
 setnet_argget.add_argument( "--vlanid", "-vlanid", type = int, help = "The VLAN ID to set" )
 setnet_argget.add_argument( "--vlanpriority", "-vlanpriority", type = int, help = "The VLAN priority to set" )


### PR DESCRIPTION
"Enabled" was added to the DHCPv6 operation mode list in favor of "Stateless" and "Stateful".