### PR TITLE
Added missing check for presence of 'Sensors' when deciding which model to follow for collecting sensor info

### DIFF
--- a/redfish_utilities/sensors.py
+++ b/redfish_utilities/sensors.py
@@ -50,7 +50,7 @@ def get_sensors( context , use_id = False ):
         get_discrete_status( "State", chassis.dict, chassis_instance["Readings"] )
 
         # If the chassis contains any of the newer power/thermal models, scan based on the common sensor model
-        if "EnvironmentMetrics" in chassis.dict or "PowerSubsystem" in chassis.dict or "ThermalSubsystem" in chassis.dict:
+        if "EnvironmentMetrics" in chassis.dict or "PowerSubsystem" in chassis.dict or "ThermalSubsystem" in chassis.dict or "Sensors" in chassis.dict:
             # Get readings from the EnvironmentMetrics resource if available
             if "EnvironmentMetrics" in chassis.dict:
                 environment = context.get( chassis.dict["EnvironmentMetrics"]["@odata.id"] )


### PR DESCRIPTION
"Sensors" can be standalone for small modules or other devices that do not implement power/thermal subsystem info.