### PR TITLE
Added protection from BrokenPipeError exceptions when piping log output

### DIFF
--- a/scripts/rf_logs.py
+++ b/scripts/rf_logs.py
@@ -18,6 +18,7 @@ import redfish
 import redfish_utilities
 import traceback
 import sys
+from signal import signal, SIGPIPE, SIG_DFL
 from redfish.messages import RedfishPasswordChangeRequiredError
 
 # Get the input arguments
@@ -87,6 +88,7 @@ try:
     else:
         # Print log was requested
         log_entries = redfish_utilities.get_log_entries(redfish_obj, container_type, container_id, args.log)
+        signal(SIGPIPE, SIG_DFL)
         redfish_utilities.print_log_entries(log_entries, args.details)
 except Exception as e:
     if args.debug:


### PR DESCRIPTION
Fix #32 

Pattern based on comments made here: https://stackoverflow.com/questions/14207708/ioerror-errno-32-broken-pipe-when-piping-prog-py-othercmd

I did not put this in universally; not even for the log script itself. I didn't want to potentially hide other sources of SIGPIPE. So, I'd like to keep this selective before we do things like print data to the console.