### PR TITLE
Fixed 'list' commands for 'rf_power_equipment.py' and 'rf_thermal_equipment.py' to handle cases where properties are not supported or null

### DIFF
--- a/redfish_utilities/power_equipment.py
+++ b/redfish_utilities/power_equipment.py
@@ -263,11 +263,11 @@ def print_power_equipment_summary(power_equipment_summary):
             for equipment in power_equipment_summary[equipment_type]:
                 print(
                     summary_line_format.format(
-                        equipment["Id"],
-                        equipment["Model"],
-                        equipment["SerialNumber"],
-                        equipment["State"],
-                        equipment["Health"],
+                        equipment["Id"] if equipment["Id"] else "",
+                        equipment["Model"] if equipment["Model"] else "",
+                        equipment["SerialNumber"] if equipment["SerialNumber"] else "",
+                        equipment["State"] if equipment["State"] else "",
+                        equipment["Health"] if equipment["Health"] else "",
                     )
                 )
             print("")

--- a/redfish_utilities/thermal_equipment.py
+++ b/redfish_utilities/thermal_equipment.py
@@ -162,11 +162,11 @@ def print_thermal_equipment_summary(thermal_equipment_summary):
             for equipment in thermal_equipment_summary[equipment_type]:
                 print(
                     summary_line_format.format(
-                        equipment["Id"],
-                        equipment["Model"],
-                        equipment["SerialNumber"],
-                        equipment["State"],
-                        equipment["Health"],
+                        equipment["Id"] if equipment["Id"] else "",
+                        equipment["Model"] if equipment["Model"] else "",
+                        equipment["SerialNumber"] if equipment["SerialNumber"] else "",
+                        equipment["State"] if equipment["State"] else "",
+                        equipment["Health"] if equipment["Health"] else "",
                     )
                 )
             print("")


### PR DESCRIPTION
Reported by a user when looking at a PDU that did not support one of the properties displayed with "list".