### PR TITLE
Corrected the regex pattern when trying to discover the local system's address when directly hosting firmware images

### DIFF
--- a/scripts/rf_update.py
+++ b/scripts/rf_update.py
@@ -149,7 +149,7 @@ try:
             # TODO: Find a better way of getting your own IP address
             # socket.gethostbyname( socket.gethostname() ) returns 127.0.0.1 on many systems
             # This will open a socket with the target, and pulls the address of the socket
-            groups = re.search("^(https?)://([^:]+)(:(\d+))?$", args.rhost)
+            groups = re.search("^(https?)://([^:]+)(:(\\d+))?$", args.rhost)
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             remote_port = groups.group(4)
             if remote_port is None:


### PR DESCRIPTION
With Python3.12, a warning pops up about the incorrect escaping of `\d`. Need an additional `\`.