### PR TITLE
Added new global config to automatically internalize task monitoring for select operations

### DIFF
--- a/redfish_utilities/config.py
+++ b/redfish_utilities/config.py
@@ -9,9 +9,14 @@ Configuration Settings
 File : config.py
 
 Brief : This file contains configuration settings for the module; useful for
-        debugging issues encountered on live systems
+        debugging issues encountered on live systems or configuring global
+        options.
 """
 
 # Leverage known workarounds for non-conformant services, such as bypassing
 # unexpected 4XX responses, missing properties, and malformed URIs
 __workarounds__ = False
+
+# Automate task handling for POST/PATCH/PUT/DELETE operations that should
+# always be "fast"
+__auto_task_handling__ = False

--- a/scripts/rf_accounts.py
+++ b/scripts/rf_accounts.py
@@ -54,6 +54,9 @@ argget.add_argument("--unlock", "-unlock", type=str, help="Unlocks a user accoun
 argget.add_argument("--debug", action="store_true", help="Creates debug file showing HTTP traces and exceptions")
 args = argget.parse_args()
 
+# Always let the calls for account management block until the underlying task is complete
+redfish_utilities.config.__auto_task_handling__ = True
+
 if args.debug:
     log_file = "rf_accounts-{}.log".format(datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S"))
     log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
Fix #191 

Currently limiting the scope to account operations; will need to evaluate other operations over time to see what we can safely allow to block.