### PR TITLE
Add HttpHeaders parameter support to event subscriptions

### DIFF
--- a/docs/rf_event_service.md
+++ b/docs/rf_event_service.md
@@ -96,6 +96,7 @@ usage: rf_event_service.py subscribe [-h] --destination DESTINATION
                                      [--resourcetypes RESOURCETYPES [RESOURCETYPES ...]]
                                      [--registries REGISTRIES [REGISTRIES ...]]
                                      [--eventtypes EVENTTYPES [EVENTTYPES ...]]
+                                     [--httpheaders HTTPHEADERS [HTTPHEADERS ...]]
 
 required arguments:
   --destination DESTINATION, -dest DESTINATION
@@ -118,6 +119,12 @@ optional arguments:
                         A list of event types for the subscription; this
                         option has been deprecated in favor of other methods
                         such as 'resource types' and 'registries'
+  --httpheaders HTTPHEADERS [HTTPHEADERS ...], -hh HTTPHEADERS [HTTPHEADERS ...]
+                        A list of HTTP headers to include in event deliveries
+                        in the format 'HeaderName:HeaderValue' (e.g.,
+                        'Authorization:Basic user:password'). For Basic
+                        Authentication, credentials will be automatically
+                        Base64 encoded.
 ```
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.

--- a/redfish_utilities/event_service.py
+++ b/redfish_utilities/event_service.py
@@ -164,6 +164,12 @@ def print_event_subscriptions(subscriptions):
             print(subscription_line_format.format("", "Registries", ", ".join(subscription["RegistryPrefixes"])))
         if "ResourceTypes" in subscription:
             print(subscription_line_format.format("", "Resource Types", ", ".join(subscription["ResourceTypes"])))
+        if "HttpHeaders" in subscription:
+            header_list = []
+            for header in subscription["HttpHeaders"]:
+                header_names = list(header.keys())
+                header_list.extend(header_names)
+            print(subscription_line_format.format("", "HTTP Headers", ", ".join(header_list)))
 
 
 def create_event_subscription(
@@ -178,6 +184,7 @@ def create_event_subscription(
     origins=None,
     subordinate_resources=None,
     event_types=None,
+    http_headers=None,
 ):
     """
     Creates an event subscription
@@ -194,6 +201,7 @@ def create_event_subscription(
         origins: The origins for the subscription
         subordinate_resources: Indicates if subordinate resources to those referenced by 'origins' will also be monitored
         event_types: The event types for the subscription; this method for subscriptions has been deprecated for other controls
+        http_headers: The HTTP headers to include in event messages sent to the destination
 
     Returns:
         The response of the POST
@@ -225,6 +233,8 @@ def create_event_subscription(
         payload["SubordinateResources"] = subordinate_resources
     if event_types is not None:
         payload["EventTypes"] = event_types
+    if http_headers is not None:
+        payload["HttpHeaders"] = http_headers
 
     # Create the subscription
     response = context.post(event_service["Subscriptions"]["@odata.id"], body=payload)

--- a/scripts/rf_event_service.py
+++ b/scripts/rf_event_service.py
@@ -12,6 +12,7 @@ Brief : This script uses the redfish_utilities module to manage the event servic
 """
 
 import argparse
+import base64
 import datetime
 import logging
 import redfish
@@ -57,6 +58,13 @@ sub_argget.add_argument(
     nargs="+",
     help="A list of event types for the subscription; this option has been deprecated in favor of other methods such as 'resource types' and 'registries'",
 )
+sub_argget.add_argument(
+    "--httpheaders",
+    "-hh",
+    type=str,
+    nargs="+",
+    help="A list of HTTP headers to include in event deliveries in the format 'HeaderName:HeaderValue'",
+)
 unsub_argget = subparsers.add_parser("unsubscribe", help="Deletes an event subscription")
 unsub_argget.add_argument(
     "--id", "-i", type=str, required=True, help="The identifier of the event subscription to be deleted"
@@ -85,6 +93,28 @@ except Exception:
 exit_code = 0
 try:
     if args.command == "subscribe":
+        # Parse HTTP headers from 'HeaderName:HeaderValue'
+        http_headers = None
+        if args.httpheaders:
+            http_headers = []
+            for header_str in args.httpheaders:
+                if ':' in header_str:
+                    header_name, header_value = header_str.split(':', 1)
+                    header_name = header_name.strip()
+                    header_value = header_value.strip()
+
+                    # Special handling for Basic Authentication - Base64 encode credentials
+                    if header_name == "Authorization" and header_value.startswith("Basic "):
+                        credentials = header_value[6:]
+                        # Only encode if not already Base64 encoded
+                        if ':' in credentials:
+                            credentials_b64 = base64.b64encode(credentials.encode()).decode()
+                            header_value = f"Basic {credentials_b64}"
+
+                    http_headers.append({header_name: header_value})
+                else:
+                    print("Warning: Invalid header format '{}', expected 'HeaderName:HeaderValue'".format(header_str))
+
         response = redfish_utilities.create_event_subscription(
             redfish_obj,
             args.destination,
@@ -94,6 +124,7 @@ try:
             resource_types=args.resourcetypes,
             registries=args.registries,
             event_types=args.eventtypes,
+            http_headers=http_headers,
         )
         print("Created subscription '{}'".format(response.getheader("Location")))
     elif args.command == "unsubscribe":


### PR DESCRIPTION
- Add http_headers parameter to create_event_subscription() function
- Update print_event_subscriptions() to display HttpHeaders
- Add --httpheaders argument to rf_event_service.py script
- Implement automatic Base64 encoding for Basic Authentication
- Update documentation with HttpHeaders usage

This enables event subscriptions to include custom HTTP headers (such as Authorization headers) that the Redfish service will send with each event delivery, supporting authenticated event listeners.

Changes:
- redfish_utilities/event_service.py: Added http_headers parameter
- scripts/rf_event_service.py: Added -hh/--httpheaders CLI argument
- docs/rf_event_service.md: Updated with HttpHeaders documentation

The implementation is fully backward compatible - the http_headers parameter is optional and defaults to None.