### PR TITLE
Updated 'rf_certificates.py' to reduce the required argument list when generating a CSR

### DIFF
--- a/docs/rf_certificates.md
+++ b/docs/rf_certificates.md
@@ -126,6 +126,9 @@ required arguments:
   --certificatecollection CERTIFICATECOLLECTION, -col CERTIFICATECOLLECTION
                         The URI of the certificate collection where the signed
                         certificate will be installed
+
+optional arguments:
+  -h, --help            show this help message and exit
   --commonname COMMONNAME, -cn COMMONNAME
                         The common name of the component to secure
   --organization ORGANIZATION, -o ORGANIZATION
@@ -142,9 +145,6 @@ required arguments:
   --country COUNTRY, -c COUNTRY
                         The two-letter country code of the organization making
                         the request
-
-optional arguments:
-  -h, --help            show this help message and exit
   --email EMAIL, -email EMAIL
                         The email address of the contact within the
                         organization making the request

--- a/redfish_utilities/certificates.py
+++ b/redfish_utilities/certificates.py
@@ -162,13 +162,13 @@ def get_generate_csr_info(context):
 
 def generate_csr(
     context,
-    common_name,
-    organization,
-    organizational_unit,
-    city,
-    state,
-    country,
     cert_col,
+    common_name=None,
+    organization=None,
+    organizational_unit=None,
+    city=None,
+    state=None,
+    country=None,
     email=None,
     key_pair_alg=None,
     key_bit_len=None,
@@ -179,13 +179,13 @@ def generate_csr(
 
     Args:
         context: The Redfish client object with an open session
+        cert_col: The URI of the certificate collection where the signed certificate will be installed
         common_name: The common name of the component to secure
         organization: The name of the organization making the request
         organizational_unit: The name of the unit in the organization making the request
         city: The city or locality of the organization making the request
         state: The state, province, or region of the organization making the request
         country: The two-letter country code of the organization making the request
-        cert_col: The URI of the certificate collection where the signed certificate will be installed
         email: The email address of the contact within the organization making the request
         key_pair_alg: The type of key-pair for use with signing algorithms
         key_bit_len: The length of the key, in bits, if the key pair algorithm supports key size
@@ -201,13 +201,19 @@ def generate_csr(
     # Build the payload
     payload = {
         "CertificateCollection": {"@odata.id": cert_col},
-        "CommonName": common_name,
-        "Organization": organization,
-        "OrganizationalUnit": organizational_unit,
-        "City": city,
-        "State": state,
-        "Country": country,
     }
+    if common_name is not None:
+        payload["CommonName"] = common_name
+    if organization is not None:
+        payload["Organization"] = organization
+    if organizational_unit is not None:
+        payload["OrganizationalUnit"] = organizational_unit
+    if city is not None:
+        payload["City"] = city
+    if state is not None:
+        payload["State"] = state
+    if country is not None:
+        payload["Country"] = country
     if email is not None:
         payload["Email"] = email
     if key_pair_alg is not None:

--- a/scripts/rf_certificates.py
+++ b/scripts/rf_certificates.py
@@ -45,35 +45,19 @@ csr_argget.add_argument(
     required=True,
     help="The URI of the certificate collection where the signed certificate will be installed",
 )
+csr_argget.add_argument("--commonname", "-cn", type=str, help="The common name of the component to secure")
 csr_argget.add_argument(
-    "--commonname", "-cn", type=str, required=True, help="The common name of the component to secure"
+    "--organization", "-o", type=str, help="The name of the unit in the organization making the request"
 )
 csr_argget.add_argument(
-    "--organization", "-o", type=str, required=True, help="The name of the unit in the organization making the request"
+    "--organizationalunit", "-ou", type=str, help="The name of the unit in the organization making the request"
+)
+csr_argget.add_argument("--city", "-l", type=str, help="The city or locality of the organization making the request")
+csr_argget.add_argument(
+    "--state", "-st", type=str, help="The state, province, or region of the organization making the request"
 )
 csr_argget.add_argument(
-    "--organizationalunit",
-    "-ou",
-    type=str,
-    required=True,
-    help="The name of the unit in the organization making the request",
-)
-csr_argget.add_argument(
-    "--city", "-l", type=str, required=True, help="The city or locality of the organization making the request"
-)
-csr_argget.add_argument(
-    "--state",
-    "-st",
-    type=str,
-    required=True,
-    help="The state, province, or region of the organization making the request",
-)
-csr_argget.add_argument(
-    "--country",
-    "-c",
-    type=str,
-    required=True,
-    help="The two-letter country code of the organization making the request",
+    "--country", "-c", type=str, help="The two-letter country code of the organization making the request"
 )
 csr_argget.add_argument(
     "--email", "-email", type=str, help="The email address of the contact within the organization making the request"
@@ -151,13 +135,13 @@ try:
         print("Generating cerficiate signing request...")
         response = redfish_utilities.generate_csr(
             redfish_obj,
+            args.certificatecollection,
             args.commonname,
             args.organization,
             args.organizationalunit,
             args.city,
             args.state,
             args.country,
-            args.certificatecollection,
             args.email,
             args.keyalg,
             args.keylen,


### PR DESCRIPTION
2026.1 removed the requirement for CommonName to be specified, and earlier versions removed other parameters as required from the GenerateCSR action.